### PR TITLE
Expose ICON_WIDTH and TOGGLE_WIDTH for external use

### DIFF
--- a/src/elements/element.rs
+++ b/src/elements/element.rs
@@ -596,8 +596,8 @@ impl NbtElement {
 
 /// "Rendering" related functions
 impl NbtElement {
-	const ICON_WIDTH: usize = 16;
-	const TOGGLE_WIDTH: usize = 16;
+	pub const ICON_WIDTH: usize = 16;
+	pub const TOGGLE_WIDTH: usize = 16;
 	
 	pub const INITIAL_DEPTH_WIDTH: usize = Self::TOGGLE_WIDTH + Self::ICON_WIDTH;
 	pub const DEPTH_INCREMENT_WIDTH: usize = Self::ICON_WIDTH;


### PR DESCRIPTION
Fixes E0624 caused by accessing private constants in workbench/tab/mod.rs

First instance of error message:
```
error[E0624]: associated constant `ICON_WIDTH` is private
   --> src/workbench/tab/mod.rs:419:46
    |
419 |             selected_text.indices.len() * NbtElement::ICON_WIDTH + NbtElement::TOGGLE_WIDTH + NbtElement::ICON_WIDTH + SelectedText::PREFIXING_SPA...
    |                                                       ^^^^^^^^^^ private associated constant
    |
   ::: src/elements/element.rs:599:2
    |
599 |     const ICON_WIDTH: usize = 16;
    |     ----------------------- private associated constant defined here

error[E0624]: associated constant `TOGGLE_WIDTH` is private
   --> src/workbench/tab/mod.rs:419:71
    |
419 |             selected_text.indices.len() * NbtElement::ICON_WIDTH + NbtElement::TOGGLE_WIDTH + NbtElement::ICON_WIDTH + SelectedText::PREFIXING_SPA...
    |                                                                                ^^^^^^^^^^^^ private associated constant
    |
   ::: src/elements/element.rs:600:2
    |
600 |     const TOGGLE_WIDTH: usize = 16;
    |     ------------------------- private associated constant defined here
```